### PR TITLE
feat: add abort streaming response support

### DIFF
--- a/src/components/excalidraw/chat-panel.tsx
+++ b/src/components/excalidraw/chat-panel.tsx
@@ -3,19 +3,20 @@ import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
-import { 
-  Send, 
-  Loader2, 
-  Plus, 
-  Trash2, 
-  MessageSquare, 
+import {
+  Send,
+  Loader2,
+  Plus,
+  Trash2,
+  MessageSquare,
   ChevronLeft,
   ChevronRight,
   Sparkles,
   CheckSquare,
   Brain,
   ChevronDown,
-  ChevronUp
+  ChevronUp,
+  Square
 } from 'lucide-react'
 import { useChatHistory, type ChatMessage } from './use-chat-history'
 import { parseExcalidrawElements, type ParsedElement } from './element-parser'
@@ -37,6 +38,7 @@ export function ChatPanel({ className, onElementsGenerated, excalidrawRef }: Cha
   const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]) // 选中元素的ID列表
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
   
   const {
     sessions,
@@ -151,35 +153,44 @@ export function ChatPanel({ className, onElementsGenerated, excalidrawRef }: Cha
       deleteElements: (ids: string[]) => excalidrawRef?.current?.deleteElements(ids) || { deleted: [], notFound: ids }
     }
 
-    await streamChat(
-      userMessage,
-      (chunk) => {
-        fullText += chunk
-        updateMessage(sessionId!, assistantMessageId, fullText)
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
 
-        // 解析元素并渲染
-        const { elements, remainingBuffer } = parseExcalidrawElements(fullText, processedLength)
+    try {
+      await streamChat(
+        userMessage,
+        (chunk) => {
+          fullText += chunk
+          updateMessage(sessionId!, assistantMessageId, fullText)
+
+          // 解析元素并渲染
+          const { elements, remainingBuffer } = parseExcalidrawElements(fullText, processedLength)
+          if (elements.length > 0) {
+            onElementsGenerated?.(elements)
+            processedLength = fullText.length - remainingBuffer.length
+          }
+        },
+        (error) => {
+          console.error('Chat error:', error)
+          updateMessage(sessionId!, assistantMessageId, `抱歉，发生了错误：${error.message}`)
+        },
+        undefined,
+        selectedElements, // 传递选中的元素
+        toolExecutor, // 传递工具执行器
+        abortController.signal
+      )
+
+      // 最终解析（仅未中断时）
+      if (!abortController.signal.aborted) {
+        const { elements } = parseExcalidrawElements(fullText, processedLength)
         if (elements.length > 0) {
           onElementsGenerated?.(elements)
-          processedLength = fullText.length - remainingBuffer.length
         }
-      },
-      (error) => {
-        console.error('Chat error:', error)
-        updateMessage(sessionId!, assistantMessageId, `抱歉，发生了错误：${error.message}`)
-      },
-      undefined,
-      selectedElements, // 传递选中的元素
-      toolExecutor // 传递工具执行器
-    )
-
-    // 最终解析
-    const { elements } = parseExcalidrawElements(fullText, processedLength)
-    if (elements.length > 0) {
-      onElementsGenerated?.(elements)
+      }
+    } finally {
+      abortControllerRef.current = null
+      setIsLoading(false)
     }
-
-    setIsLoading(false)
   }
 
   // 处理按键（输入法激活时不发送）
@@ -319,6 +330,15 @@ export function ChatPanel({ className, onElementsGenerated, excalidrawRef }: Cha
             <div className="flex items-center gap-2 text-foreground/50">
               <Loader2 className="w-4 h-4 animate-spin" />
               <span className="text-sm">AI 正在思考...</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-foreground/50 hover:text-foreground"
+                onClick={() => abortControllerRef.current?.abort()}
+              >
+                <Square className="w-3 h-3 fill-current" />
+                停止
+              </Button>
             </div>
           )}
           
@@ -370,12 +390,18 @@ export function ChatPanel({ className, onElementsGenerated, excalidrawRef }: Cha
             />
             <Button
               size="icon"
-              onClick={handleSend}
-              disabled={!input.trim() || isLoading}
+              onClick={() => {
+                if (isLoading) {
+                  abortControllerRef.current?.abort()
+                } else {
+                  handleSend()
+                }
+              }}
+              disabled={!isLoading && !input.trim()}
               className="shrink-0 w-9 h-9"
             >
               {isLoading ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
+                <Square className="w-4 h-4 fill-current" />
               ) : (
                 <Send className="w-4 h-4" />
               )}

--- a/src/components/excalidraw/mobile-input.tsx
+++ b/src/components/excalidraw/mobile-input.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Card } from '@/components/ui/card'
-import { Send, Loader2, Trash2 } from 'lucide-react'
+import { Send, Loader2, Trash2, Square } from 'lucide-react'
 import { useChatHistory } from './use-chat-history'
 import { parseExcalidrawElements, type ParsedElement } from './element-parser'
 import { streamChat, isConfigValid, getAIConfig } from '@/lib/ai'
@@ -24,6 +24,7 @@ export function MobileInput({
   const [isLoading, setIsLoading] = useState(false)
   const [isComposing, setIsComposing] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
   
   const {
     currentSessionId,
@@ -68,40 +69,52 @@ export function MobileInput({
     let processedLength = 0
     let hasGeneratedElements = false
 
-    await streamChat(
-      userMessage,
-      (chunk) => {
-        fullText += chunk
-        updateMessage(sessionId!, assistantMessageId, fullText)
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
 
-        // 解析元素并渲染
-        const { elements, remainingBuffer } = parseExcalidrawElements(fullText, processedLength)
+    try {
+      await streamChat(
+        userMessage,
+        (chunk) => {
+          fullText += chunk
+          updateMessage(sessionId!, assistantMessageId, fullText)
+
+          // 解析元素并渲染
+          const { elements, remainingBuffer } = parseExcalidrawElements(fullText, processedLength)
+          if (elements.length > 0) {
+            onElementsGenerated?.(elements)
+            processedLength = fullText.length - remainingBuffer.length
+            hasGeneratedElements = true
+          }
+        },
+        (error) => {
+          console.error('Chat error:', error)
+          updateMessage(sessionId!, assistantMessageId, `抱歉，发生了错误：${error.message}`)
+          showToast?.('生成失败，请重试', 2000)
+        },
+        undefined,
+        undefined,
+        undefined,
+        abortController.signal
+      )
+
+      // 最终解析（仅未中断时）
+      if (!abortController.signal.aborted) {
+        const { elements } = parseExcalidrawElements(fullText, processedLength)
         if (elements.length > 0) {
           onElementsGenerated?.(elements)
-          processedLength = fullText.length - remainingBuffer.length
           hasGeneratedElements = true
         }
-      },
-      (error) => {
-        console.error('Chat error:', error)
-        updateMessage(sessionId!, assistantMessageId, `抱歉，发生了错误：${error.message}`)
-        showToast?.('生成失败，请重试', 2000)
+
+        // 显示完成提示
+        if (hasGeneratedElements) {
+          showToast?.('✨ 图形已生成到画布', 2000)
+        }
       }
-    )
-
-    // 最终解析
-    const { elements } = parseExcalidrawElements(fullText, processedLength)
-    if (elements.length > 0) {
-      onElementsGenerated?.(elements)
-      hasGeneratedElements = true
+    } finally {
+      abortControllerRef.current = null
+      updateLoading(false)
     }
-
-    // 显示完成提示
-    if (hasGeneratedElements) {
-      showToast?.('✨ 图形已生成到画布', 2000)
-    }
-
-    updateLoading(false)
   }
 
   // 处理按键
@@ -140,15 +153,21 @@ export function MobileInput({
           disabled={isLoading}
         />
 
-        {/* 发送按钮 */}
+        {/* 发送/停止按钮 */}
         <Button
           size="icon"
-          onClick={handleSend}
-          disabled={!input.trim() || isLoading}
+          onClick={() => {
+            if (isLoading) {
+              abortControllerRef.current?.abort()
+            } else {
+              handleSend()
+            }
+          }}
+          disabled={!isLoading && !input.trim()}
           className="shrink-0 w-9 h-9"
         >
           {isLoading ? (
-            <Loader2 className="w-4 h-4 animate-spin" />
+            <Square className="w-4 h-4 fill-current" />
           ) : (
             <Send className="w-4 h-4" />
           )}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -179,7 +179,8 @@ export async function streamChat(
   onError?: (error: Error) => void,
   config?: AIConfig,
   selectedElements?: ElementSummary[],
-  toolExecutor?: ToolExecutor
+  toolExecutor?: ToolExecutor,
+  signal?: AbortSignal
 ): Promise<void> {
   const finalConfig = config || getAIConfig()
 
@@ -197,7 +198,7 @@ export async function streamChat(
   ]
 
   // 递归处理，支持多轮工具调用
-  await processChat(messages, finalConfig, onChunk, onError, toolExecutor)
+  await processChat(messages, finalConfig, onChunk, onError, toolExecutor, 3, signal)
 }
 
 /**
@@ -209,7 +210,8 @@ async function processChat(
   onChunk: (content: string) => void,
   onError?: (error: Error) => void,
   toolExecutor?: ToolExecutor,
-  maxToolCalls = 3  // 最大工具调用次数，防止无限循环
+  maxToolCalls = 3,  // 最大工具调用次数，防止无限循环
+  signal?: AbortSignal
 ): Promise<void> {
   try {
     const requestBody: Record<string, unknown> = {
@@ -231,6 +233,7 @@ async function processChat(
         'Authorization': `Bearer ${config.apiKey}`,
       },
       body: JSON.stringify(requestBody),
+      signal,
     })
 
     if (!response.ok) {
@@ -347,9 +350,13 @@ async function processChat(
       onChunk('\n\n[正在分析画布内容...]\n\n')
 
       // 递归调用继续对话
-      await processChat(messages, config, onChunk, onError, toolExecutor, maxToolCalls - 1)
+      await processChat(messages, config, onChunk, onError, toolExecutor, maxToolCalls - 1, signal)
     }
   } catch (error) {
+    const isAbort = error instanceof DOMException
+      ? error.name === 'AbortError'
+      : error instanceof Error && (error.name === 'AbortError' || error.message?.includes('aborted'))
+    if (isAbort) return
     onError?.(error instanceof Error ? error : new Error(String(error)))
   }
 }


### PR DESCRIPTION
Add ability to interrupt AI response during streaming. The send button becomes a stop button (square icon) while the AI is generating, and an inline stop button appears next to the "thinking" indicator.

Implementation:
- Pass AbortSignal through streamChat() and processChat() to fetch()
- Suppress AbortError gracefully without showing error to user
- Wrap streaming in try/finally to guarantee loading state cleanup
- Skip final element parse on abort (already parsed incrementally)
- Works for both desktop (ChatPanel) and mobile (MobileInput) layouts

close : https://github.com/co-pine/ai-excalidraw/issues/8